### PR TITLE
Local rag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,10 @@ dependencies {
     implementation("org.json:json:20180813")
     implementation("org.jsoup:jsoup:1.15.3")
     implementation("net.gcardone.junidecode:junidecode:0.5.2")
+    implementation("com.microsoft.onnxruntime:onnxruntime:1.23.2")
+    implementation("ai.djl.huggingface:tokenizers:0.36.0")
+    implementation("org.apache.lucene:lucene-core:10.3.2")
+    implementation("org.apache.lucene:lucene-analysis-common:10.3.2")
 
     // Needed by MCP toolset DTOs; compiler plugin generates serializers.
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,6 +136,37 @@ dependencies {
     }
 }
 
+val modelDir = layout.projectDirectory.dir(".mcp-model")
+val e5ModelUrl = "https://huggingface.co/intfloat/e5-small/resolve/main/model.onnx?download=true"
+val e5TokenizerUrl = "https://huggingface.co/intfloat/e5-small/resolve/main/tokenizer.json?download=true"
+
+tasks.register("downloadE5Model") {
+    group = "mcp"
+    description = "Download e5-small ONNX model and tokenizer if missing"
+    doLast {
+        val dirFile = modelDir.asFile
+        if (!dirFile.exists()) {
+            dirFile.mkdirs()
+        }
+        val modelFile = modelDir.file("model.onnx").asFile
+        val tokenizerFile = modelDir.file("tokenizer.json").asFile
+
+        fun downloadIfMissing(url: String, target: java.io.File) {
+            if (target.exists() && target.length() > 0) return
+            java.net.URL(url).openStream().use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            }
+        }
+
+        downloadIfMissing(e5ModelUrl, modelFile)
+        downloadIfMissing(e5TokenizerUrl, tokenizerFile)
+    }
+}
+
+tasks.named("runIde") {
+    dependsOn("downloadE5Model")
+}
+
 intellijPlatform {
     pluginVerification {
         ides {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.net.URL
+
 plugins {
     java
     // Must be compatible with Kotlin compiler bundled with IntelliJ IDEA 2025.3 (metadata 2.2.0)
@@ -8,6 +11,8 @@ plugins {
 
 val ideaVersion = "2025.3"
 val javaVersion = 21
+val onnxRuntimeVersion = "1.20.0"
+val djlTokenizersVersion = "0.33.0"
 
 group = "com.lsfusion"
 version = file("META-INF/plugin.xml").let {
@@ -24,6 +29,15 @@ repositories {
     maven("https://plugins.jetbrains.com/maven")
     intellijPlatform {
         defaultRepositories()
+    }
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "com.microsoft.onnxruntime") {
+            useVersion(onnxRuntimeVersion)
+            because("Keep all ONNX Runtime jars on one version")
+        }
     }
 }
 
@@ -111,8 +125,8 @@ dependencies {
     implementation("org.json:json:20180813")
     implementation("org.jsoup:jsoup:1.15.3")
     implementation("net.gcardone.junidecode:junidecode:0.5.2")
-    implementation("com.microsoft.onnxruntime:onnxruntime:1.23.2")
-    implementation("ai.djl.huggingface:tokenizers:0.36.0")
+    implementation("com.microsoft.onnxruntime:onnxruntime:$onnxRuntimeVersion")
+    implementation("ai.djl.huggingface:tokenizers:$djlTokenizersVersion")
     implementation("org.apache.lucene:lucene-core:10.3.2")
     implementation("org.apache.lucene:lucene-analysis-common:10.3.2")
 
@@ -139,10 +153,15 @@ dependencies {
 val modelDir = layout.projectDirectory.dir(".mcp-model")
 val e5ModelUrl = "https://huggingface.co/intfloat/e5-small/resolve/main/model.onnx?download=true"
 val e5TokenizerUrl = "https://huggingface.co/intfloat/e5-small/resolve/main/tokenizer.json?download=true"
+val onnxNativeDir = layout.buildDirectory.dir("onnxruntime-native")
+val onnxTempDir = layout.buildDirectory.dir("onnxruntime-tmp")
+val onnxRuntimeDll = onnxNativeDir.map { it.file("onnxruntime.dll") }
+val onnxRuntimeJniDll = onnxNativeDir.map { it.file("onnxruntime4j_jni.dll") }
 
 tasks.register("downloadE5Model") {
     group = "mcp"
     description = "Download e5-small ONNX model and tokenizer if missing"
+    notCompatibleWithConfigurationCache("Downloads model files to project directory")
     doLast {
         val dirFile = modelDir.asFile
         if (!dirFile.exists()) {
@@ -151,9 +170,9 @@ tasks.register("downloadE5Model") {
         val modelFile = modelDir.file("model.onnx").asFile
         val tokenizerFile = modelDir.file("tokenizer.json").asFile
 
-        fun downloadIfMissing(url: String, target: java.io.File) {
+        fun downloadIfMissing(url: String, target: File) {
             if (target.exists() && target.length() > 0) return
-            java.net.URL(url).openStream().use { input ->
+            URL(url).openStream().use { input ->
                 target.outputStream().use { output -> input.copyTo(output) }
             }
         }
@@ -163,8 +182,44 @@ tasks.register("downloadE5Model") {
     }
 }
 
-tasks.named("runIde") {
-    dependsOn("downloadE5Model")
+val extractOnnxRuntimeNative by tasks.registering(Sync::class) {
+    group = "mcp"
+    description = "Extract ONNX Runtime native libs into build dir"
+    val runtimeClasspath = configurations.runtimeClasspath
+    from({
+        runtimeClasspath.get()
+            .filter { it.name.startsWith("onnxruntime-") && it.extension == "jar" }
+            .map { zipTree(it) }
+    }) {
+        include("**/onnxruntime*.dll")
+        include("**/onnxruntime_providers_*.dll")
+        include("**/onnxruntime*.so")
+        include("**/onnxruntime*.dylib")
+        include("**/libonnxruntime*.dylib")
+        include("**/onnxruntime4j_jni*")
+        include("**/libonnxruntime4j_jni*")
+    }
+    into(onnxNativeDir)
+    includeEmptyDirs = false
+    duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.EXCLUDE
+    eachFile { path = name }
+}
+
+val createOnnxTempDir by tasks.registering {
+    group = "mcp"
+    description = "Create ONNX Runtime temp dir"
+    doLast {
+        onnxTempDir.get().asFile.mkdirs()
+    }
+}
+
+tasks.withType<org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask>().configureEach {
+    dependsOn("downloadE5Model", extractOnnxRuntimeNative, createOnnxTempDir)
+    jvmArgs("-Dlsfusion.mcp.embedding.modelDir=${modelDir.asFile.absolutePath}")
+    jvmArgs("-Donnxruntime.native.path=${onnxNativeDir.get().asFile.absolutePath}")
+    jvmArgs("-Donnxruntime.native.onnxruntime.path=${onnxRuntimeDll.get().asFile.absolutePath}")
+    jvmArgs("-Donnxruntime.native.onnxruntime4j_jni.path=${onnxRuntimeJniDll.get().asFile.absolutePath}")
+    jvmArgs("-Djava.io.tmpdir=${onnxTempDir.get().asFile.absolutePath}")
 }
 
 intellijPlatform {

--- a/src/com/lsfusion/LSFBaseStartupActivity.java
+++ b/src/com/lsfusion/LSFBaseStartupActivity.java
@@ -7,6 +7,8 @@ import com.intellij.openapi.startup.ProjectActivity;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.impl.BulkVirtualFileListenerAdapter;
 import com.lsfusion.actions.locale.LSFPropertiesFileListener;
+import com.lsfusion.mcp.LSFMcpRagFileListener;
+import com.lsfusion.mcp.LocalMcpRagService;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +19,12 @@ public class LSFBaseStartupActivity implements ProjectActivity, DumbAware {
     public @Nullable Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
         project.getMessageBus().connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, new LSFFileEditorManagerListener());
         project.getMessageBus().connect().subscribe(VirtualFileManager.VFS_CHANGES, new BulkVirtualFileListenerAdapter(new LSFPropertiesFileListener(project)));
+        project.getMessageBus().connect().subscribe(VirtualFileManager.VFS_CHANGES, new BulkVirtualFileListenerAdapter(new LSFMcpRagFileListener(project)));
+        try {
+            LocalMcpRagService.getInstance(project).indexProjectAsync();
+        } catch (Exception ignored) {
+            // indexing service not available
+        }
         return Unit.INSTANCE;
     }
 }

--- a/src/com/lsfusion/mcp/EmbeddingProvider.java
+++ b/src/com/lsfusion/mcp/EmbeddingProvider.java
@@ -1,0 +1,11 @@
+package com.lsfusion.mcp;
+
+public interface EmbeddingProvider extends AutoCloseable {
+    float[] embed(String text) throws Exception;
+    int dimension();
+
+    @Override
+    default void close() throws Exception {
+        // no-op by default
+    }
+}

--- a/src/com/lsfusion/mcp/LSFMcpRagFileListener.java
+++ b/src/com/lsfusion/mcp/LSFMcpRagFileListener.java
@@ -1,0 +1,64 @@
+package com.lsfusion.mcp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileCopyEvent;
+import com.intellij.openapi.vfs.VirtualFileEvent;
+import com.intellij.openapi.vfs.VirtualFileListener;
+import com.intellij.openapi.vfs.VirtualFileMoveEvent;
+import com.intellij.openapi.vfs.VirtualFilePropertyEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class LSFMcpRagFileListener implements VirtualFileListener {
+    private final Project project;
+
+    public LSFMcpRagFileListener(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void contentsChanged(@NotNull VirtualFileEvent event) {
+        update(event.getFile());
+    }
+
+    @Override
+    public void fileCreated(@NotNull VirtualFileEvent event) {
+        update(event.getFile());
+    }
+
+    @Override
+    public void fileDeleted(@NotNull VirtualFileEvent event) {
+        delete(event.getFile());
+    }
+
+    @Override
+    public void fileMoved(@NotNull VirtualFileMoveEvent event) {
+        update(event.getFile());
+    }
+
+    @Override
+    public void fileCopied(@NotNull VirtualFileCopyEvent event) {
+        update(event.getFile());
+    }
+
+    @Override
+    public void propertyChanged(@NotNull VirtualFilePropertyEvent event) {
+        update(event.getFile());
+    }
+
+    private void update(VirtualFile file) {
+        try {
+            LocalMcpRagService.getInstance(project).updateFile(file);
+        } catch (Exception ignored) {
+            // service not available
+        }
+    }
+
+    private void delete(VirtualFile file) {
+        try {
+            LocalMcpRagService.getInstance(project).deleteFile(file);
+        } catch (Exception ignored) {
+            // service not available
+        }
+    }
+}

--- a/src/com/lsfusion/mcp/LocalMcpRagService.java
+++ b/src/com/lsfusion/mcp/LocalMcpRagService.java
@@ -1,0 +1,207 @@
+package com.lsfusion.mcp;
+
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.ProjectScope;
+import com.lsfusion.lang.psi.LSFFile;
+import com.lsfusion.util.LSFFileUtils;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnVectorQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class LocalMcpRagService {
+    private static final Logger LOG = Logger.getInstance(LocalMcpRagService.class);
+    private static final Key<LocalMcpRagService> KEY = Key.create("lsfusion.mcp.localRagService");
+    private static final String FIELD_ID = "elementId";
+    private static final String FIELD_FILE = "filePath";
+    private static final String FIELD_MODULE = "module";
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_CODE = "code";
+    private static final String FIELD_VECTOR = "vector";
+
+    private final Project project;
+    private final Directory directory;
+    private final IndexWriter writer;
+    private final EmbeddingProvider embeddingProvider;
+    private final AtomicBoolean indexing = new AtomicBoolean(false);
+
+    private LocalMcpRagService(Project project) throws Exception {
+        this.project = project;
+        Path base = Path.of(project.getBasePath());
+        Path indexPath = base.resolve(".mcp-index");
+        Files.createDirectories(indexPath);
+        this.directory = FSDirectory.open(indexPath);
+        this.writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()));
+        this.embeddingProvider = createEmbeddingProvider();
+    }
+
+    public static @NotNull LocalMcpRagService getInstance(@NotNull Project project) throws Exception {
+        LocalMcpRagService service = project.getUserData(KEY);
+        if (service != null) return service;
+        service = new LocalMcpRagService(project);
+        project.putUserData(KEY, service);
+        return service;
+    }
+
+    public void indexProjectAsync() {
+        if (indexing.getAndSet(true)) return;
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            long start = System.currentTimeMillis();
+            try {
+                indexProject();
+                LOG.info("MCP RAG index built in " + (System.currentTimeMillis() - start) + "ms");
+            } catch (Throwable t) {
+                LOG.warn("MCP RAG index build failed", t);
+            } finally {
+                indexing.set(false);
+            }
+        });
+    }
+
+    public void indexProject() throws Exception {
+        ReadAction.run(() -> {
+            for (LSFFile lsfFile : LSFFileUtils.getLsfFiles(ProjectScope.getAllScope(project))) {
+                indexFile(lsfFile);
+            }
+        });
+        writer.commit();
+    }
+
+    public void updateFile(@NotNull VirtualFile file) {
+        if (!file.getName().endsWith(".lsf")) return;
+        try {
+            ReadAction.run(() -> {
+                PsiFile psi = PsiManager.getInstance(project).findFile(file);
+                if (psi instanceof LSFFile lsfFile) {
+                    indexFile(lsfFile);
+                }
+            });
+            writer.commit();
+        } catch (Throwable t) {
+            LOG.warn("MCP RAG updateFile failed: " + file.getPath(), t);
+        }
+    }
+
+    public void deleteFile(@NotNull VirtualFile file) {
+        if (!file.getName().endsWith(".lsf")) return;
+        try {
+            writer.deleteDocuments(new Term(FIELD_FILE, file.getPath()));
+            writer.commit();
+        } catch (Throwable t) {
+            LOG.warn("MCP RAG deleteFile failed: " + file.getPath(), t);
+        }
+    }
+
+    public @NotNull List<String> search(@NotNull String queryText, int topK) {
+        if (queryText.isBlank()) return List.of();
+        if (embeddingProvider == null) return List.of();
+        try {
+            long start = System.currentTimeMillis();
+            float[] vector = embeddingProvider.embed(queryText);
+            if (vector.length == 0) return List.of();
+            try (IndexReader reader = DirectoryReader.open(writer)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                KnnVectorQuery query = new KnnVectorQuery(FIELD_VECTOR, vector, topK);
+                TopDocs hits = searcher.search(query, topK);
+                List<String> out = new ArrayList<>();
+                for (ScoreDoc hit : hits.scoreDocs) {
+                    Document doc = searcher.doc(hit.doc);
+                    String location = doc.get(FIELD_ID);
+                    if (location != null) out.add(location);
+                }
+                LOG.info("MCP RAG search: " + out.size() + " hits in " + (System.currentTimeMillis() - start) + "ms");
+                return out;
+            }
+        } catch (Throwable t) {
+            LOG.warn("MCP RAG search failed", t);
+            return List.of();
+        }
+    }
+
+    private void indexFile(@NotNull LSFFile file) {
+        VirtualFile vf = file.getVirtualFile();
+        if (vf == null) return;
+        try {
+            writer.deleteDocuments(new Term(FIELD_FILE, vf.getPath()));
+            for (LSFMCPDeclaration decl : LSFMCPDeclaration.getMCPDeclarations(file)) {
+                indexStatement(file, decl);
+            }
+        } catch (Throwable t) {
+            LOG.warn("MCP RAG indexFile failed: " + vf.getPath(), t);
+        }
+    }
+
+    private void indexStatement(@NotNull LSFFile file, @NotNull LSFMCPDeclaration decl) throws Exception {
+        String location = MCPSearchUtils.getLocationByStatement(decl);
+        if (location == null) return;
+        float[] vector = embeddingProvider.embed(buildText(decl));
+        if (vector.length == 0) return;
+        Document doc = new Document();
+        doc.add(new StringField(FIELD_ID, location, Field.Store.YES));
+        doc.add(new StringField(FIELD_FILE, file.getVirtualFile().getPath(), Field.Store.YES));
+        doc.add(new StringField(FIELD_MODULE, file.getModuleDeclaration() != null ? file.getModuleDeclaration().getDeclName() : "", Field.Store.YES));
+        String typeName;
+        try {
+            typeName = decl.getMCPType().apiName;
+        } catch (Throwable t) {
+            typeName = "unknown";
+        }
+        doc.add(new StringField(FIELD_TYPE, typeName, Field.Store.YES));
+        doc.add(new TextField(FIELD_CODE, decl.getText(), Field.Store.NO));
+        doc.add(new KnnVectorField(FIELD_VECTOR, vector));
+        writer.addDocument(doc);
+    }
+
+    private static String buildText(LSFMCPDeclaration decl) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(decl.getMCPType().apiName).append(' ');
+        for (var d : LSFMCPDeclaration.getNameDeclarations(decl)) {
+            if (d.getDeclName() != null) sb.append(d.getDeclName()).append(' ');
+            if (d.getCanonicalName() != null) sb.append(d.getCanonicalName()).append(' ');
+        }
+        sb.append(decl.getText());
+        return sb.toString();
+    }
+
+    private @Nullable EmbeddingProvider createEmbeddingProvider() {
+        String modelDir = System.getProperty("lsfusion.mcp.embedding.modelDir");
+        if (modelDir == null || modelDir.isBlank()) {
+            LOG.warn("MCP embedding model dir not set: set -Dlsfusion.mcp.embedding.modelDir");
+            return null;
+        }
+        try {
+            return new OnnxEmbeddingProvider(Path.of(modelDir));
+        } catch (Throwable t) {
+            LOG.warn("MCP embedding provider init failed", t);
+            return null;
+        }
+    }
+}

--- a/src/com/lsfusion/mcp/LocalMcpRagService.java
+++ b/src/com/lsfusion/mcp/LocalMcpRagService.java
@@ -137,7 +137,7 @@ public final class LocalMcpRagService {
                 List<String> out = new ArrayList<>();
                 List<ScoredId> scored = new ArrayList<>(hits.scoreDocs.length);
                 for (ScoreDoc hit : hits.scoreDocs) {
-                    Document doc = searcher.doc(hit.doc);
+                    Document doc = searcher.storedFields().document(hit.doc);
                     String location = doc.get(FIELD_ID);
                     BytesRef br = doc.getBinaryValue(FIELD_VECTOR);
                     byte[] raw = br != null ? Arrays.copyOfRange(br.bytes, br.offset, br.offset + br.length) : null;

--- a/src/com/lsfusion/mcp/McpServerService.java
+++ b/src/com/lsfusion/mcp/McpServerService.java
@@ -254,6 +254,15 @@ public final class McpServerService extends RestService {
                                 .put("type", "string")
                                 .put("description",
                                         "Element name filter as CSV (comma-separated). Word if valid ID, else Java regex."))
+                        .put("query", new JSONObject()
+                                .put("type", "string")
+                                .put("description",
+                                        "Semantic query for local RAG (vector search). CSV allowed."))
+                        .put("useVectorSearch", new JSONObject()
+                                .put("type", "boolean")
+                                .put("default", false)
+                                .put("description",
+                                        "If true, use local vector search for `query`. If false, use standard filters (names/contains)."))
                         .put("contains", new JSONObject()
                                 .put("type", "string")
                                 .put("description",
@@ -285,7 +294,7 @@ public final class McpServerService extends RestService {
                         .put("moreFilters", new JSONObject()
                                 .put("type", "string")
                                 .put("description",
-                                        "Additional filter objects of the same structure as the root. JSON array string (e.g. `[{\"names\":\"Foo\", \"modules\" : \"MyModule\"},{\"names\":\"Bar\"}]`). Results are merged (OR)."))
+                                        "Additional filter objects of the same structure as the root. JSON array string (e.g. `[{\"name\":\"Foo\", \"contains\":\"bar\", \"modules\" : \"MyModule\"},{\"query\":\"Foo\", \"useVectorSearch\":true}]`). Results are merged (OR)."))
                         .put("minSymbols", new JSONObject()
                                 .put("type", "integer")
                                 .put("minimum", 0)

--- a/src/com/lsfusion/mcp/OnnxEmbeddingProvider.java
+++ b/src/com/lsfusion/mcp/OnnxEmbeddingProvider.java
@@ -1,0 +1,167 @@
+package com.lsfusion.mcp;
+
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OnnxValue;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ONNX Runtime embedding provider using e5-small.
+ * Model directory is expected to contain:
+ * - model.onnx
+ * - tokenizer.json (HuggingFace tokenizer)
+ */
+public final class OnnxEmbeddingProvider implements EmbeddingProvider {
+    private static final Logger LOG = Logger.getInstance(OnnxEmbeddingProvider.class);
+
+    private final OrtEnvironment env;
+    private final OrtSession session;
+    private final HuggingFaceTokenizer tokenizer;
+    private final int dimension;
+    private final String inputIdsName;
+    private final String attentionMaskName;
+    private final String tokenTypeIdsName;
+    private final String outputName;
+
+    public OnnxEmbeddingProvider(@NotNull Path modelDir) throws Exception {
+        Path modelPath = modelDir.resolve("model.onnx");
+        Path tokenizerPath = modelDir.resolve("tokenizer.json");
+        if (!Files.exists(modelPath) || !Files.exists(tokenizerPath)) {
+            throw new IllegalStateException("Missing model.onnx or tokenizer.json in " + modelDir);
+        }
+
+        this.env = OrtEnvironment.getEnvironment();
+        this.session = env.createSession(modelPath.toString(), new OrtSession.SessionOptions());
+        this.tokenizer = HuggingFaceTokenizer.newInstance(tokenizerPath);
+
+        this.inputIdsName = pickInputName("input_ids");
+        this.attentionMaskName = pickInputName("attention_mask");
+        this.tokenTypeIdsName = pickInputName("token_type_ids");
+        this.outputName = pickOutputName();
+        this.dimension = inferDimension();
+    }
+
+    @Override
+    public float[] embed(String text) throws Exception {
+        var encoding = tokenizer.encode(text);
+        long[] inputIds = encoding.getIds();
+        long[] attentionMask = encoding.getAttentionMask();
+        long[] tokenTypeIds = encoding.getTypeIds();
+
+        if (tokenTypeIds == null || tokenTypeIds.length == 0) {
+            tokenTypeIds = new long[inputIds.length];
+        }
+
+        long[] shape = new long[]{1, inputIds.length};
+        try (OnnxTensor idsTensor = OnnxTensor.createTensor(env, wrapLong(inputIds), shape);
+             OnnxTensor maskTensor = OnnxTensor.createTensor(env, wrapLong(attentionMask), shape);
+             OnnxTensor typeTensor = OnnxTensor.createTensor(env, wrapLong(tokenTypeIds), shape)) {
+
+            Map<String, OnnxTensor> inputs = new HashMap<>();
+            if (inputIdsName != null) inputs.put(inputIdsName, idsTensor);
+            if (attentionMaskName != null) inputs.put(attentionMaskName, maskTensor);
+            if (tokenTypeIdsName != null) inputs.put(tokenTypeIdsName, typeTensor);
+
+            try (OrtSession.Result result = session.run(inputs)) {
+                OnnxValue value = result.get(outputName);
+                float[] vector = extractEmbedding(value, attentionMask);
+                normalize(vector);
+                return vector;
+            }
+        }
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public void close() throws Exception {
+        session.close();
+        env.close();
+    }
+
+    private String pickInputName(String preferred) {
+        if (session.getInputNames().contains(preferred)) {
+            return preferred;
+        }
+        return session.getInputNames().stream().findFirst().orElse(null);
+    }
+
+    private String pickOutputName() {
+        if (session.getOutputNames().contains("sentence_embedding")) {
+            return "sentence_embedding";
+        }
+        return session.getOutputNames().stream().findFirst().orElseThrow();
+    }
+
+    private int inferDimension() throws OrtException {
+        var outputInfo = session.getOutputInfo().get(outputName).getInfo();
+        if (outputInfo instanceof ai.onnxruntime.TensorInfo ti) {
+            long[] shape = ti.getShape();
+            if (shape.length == 2 && shape[1] > 0) {
+                return (int) shape[1];
+            }
+            if (shape.length == 3 && shape[2] > 0) {
+                return (int) shape[2];
+            }
+        }
+        return 384; // fallback for e5-small
+    }
+
+    private static long[][] wrapLong(long[] input) {
+        long[][] out = new long[1][input.length];
+        System.arraycopy(input, 0, out[0], 0, input.length);
+        return out;
+    }
+
+    private float[] extractEmbedding(OnnxValue value, long[] attentionMask) throws OrtException {
+        Object raw = value.getValue();
+        if (raw instanceof float[][] vec2d) {
+            return vec2d[0];
+        }
+        if (raw instanceof float[][][] vec3d) {
+            return meanPool(vec3d[0], attentionMask);
+        }
+        LOG.warn("Unexpected ONNX output type: " + raw.getClass().getName());
+        return new float[dimension];
+    }
+
+    private static float[] meanPool(float[][] tokenEmbeds, long[] attentionMask) {
+        int dim = tokenEmbeds[0].length;
+        float[] out = new float[dim];
+        float denom = 0f;
+        for (int i = 0; i < tokenEmbeds.length; i++) {
+            float mask = (attentionMask != null && i < attentionMask.length) ? attentionMask[i] : 1f;
+            if (mask <= 0) continue;
+            denom += mask;
+            float[] t = tokenEmbeds[i];
+            for (int d = 0; d < dim; d++) {
+                out[d] += t[d] * mask;
+            }
+        }
+        if (denom > 0) {
+            for (int d = 0; d < dim; d++) out[d] /= denom;
+        }
+        return out;
+    }
+
+    private static void normalize(float[] v) {
+        double sum = 0;
+        for (float x : v) sum += x * x;
+        double norm = Math.sqrt(sum);
+        if (norm == 0) return;
+        for (int i = 0; i < v.length; i++) v[i] /= norm;
+    }
+}


### PR DESCRIPTION
## Summary
- Added a local RAG pipeline for LSF sources with Lucene vector indexing and ONNX-based embeddings.
- Wired startup indexing and VFS-based reindexing to keep embeddings up to date.
- Added model download + native ONNX extraction to make `runIde` reliable on Windows.

## What changed vs master
**New files**
- `src/com/lsfusion/mcp/LocalMcpRagService.java` — local RAG service: indexing, vector storage, query scoring.
- `src/com/lsfusion/mcp/OnnxEmbeddingProvider.java` — ONNX Runtime embedding inference.
- `src/com/lsfusion/mcp/EmbeddingProvider.java` — embedding provider interface.
- `src/com/lsfusion/mcp/LSFMcpRagFileListener.java` — VFS listener to reindex on file changes.

**Updated**
- `src/com/lsfusion/LSFBaseStartupActivity.java` — startup indexing + listener registration.
- `src/com/lsfusion/mcp/McpServerService.java`, `src/com/lsfusion/mcp/McpToolset.kt`, `src/com/lsfusion/mcp/MCPSearchUtils.java` — integrate local RAG search results.
- `build.gradle.kts` — new dependencies + model download + native extraction + runIde JVM args.

## How it works
1) **Indexing**
- On startup, `LocalMcpRagService` scans all LSF files, extracts MCP declarations, builds a text payload and computes embeddings.
- Each record is stored in Lucene with the vector saved as a binary field.
- A VFS listener triggers reindexing on file change/delete.

2) **Query**
- Input query is embedded with ONNX Runtime.
- Results are scored via dot‑product against stored vectors and top‑K matches returned.

3) **Model + native libs**
- `downloadE5Model` fetches `model.onnx` + `tokenizer.json` into `.mcp-model`.
- ONNX native DLLs are extracted into `build/onnxruntime-native`.
- `runIde` sets `onnxruntime.native.path` and a stable temp dir for reliable loading on Windows.

## Technologies
- **ONNX Runtime (Java)** — CPU embeddings.
- **DJL HuggingFace Tokenizers** — tokenization from `tokenizer.json`.
- **Lucene** — vector storage and scoring.
- **IntelliJ Platform APIs** — startup activity, VFS listener, DumbService guard.

## Test plan
- `runIde`
- Wait for initial indexing
- Run MCP search and verify relevance
- Modify an LSF file and verify search reflects the change